### PR TITLE
Improved configuration options

### DIFF
--- a/src-php/Config/repeater-blocks.php
+++ b/src-php/Config/repeater-blocks.php
@@ -2,4 +2,8 @@
 
 return [
     'path' => 'repeaters.',
+    'images' => [
+        'field' => 'Laravel\Nova\Fields\Image',
+        'disk' => 'public',
+    ],
 ];

--- a/src-php/Fields/Repeater.php
+++ b/src-php/Fields/Repeater.php
@@ -67,7 +67,7 @@ class Repeater extends Resource
 
     public static function getMorphToArray()
     {
-        return array_merge(static::$morphTo, static::morphTo());
+        return array_merge(static::$morphTo, array_wrap(static::morphTo()));
     }
 
     /**

--- a/src-php/Repeaters/Common/Blocks/ImageBlock.php
+++ b/src-php/Repeaters/Common/Blocks/ImageBlock.php
@@ -5,7 +5,6 @@ namespace Dewsign\NovaRepeaterBlocks\Repeaters\Common\Blocks;
 use Laravel\Nova\Resource;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Text;
-use Laravel\Nova\Fields\Image;
 use Epartment\NovaDependencyContainer\HasDependencies;
 use Dewsign\NovaRepeaterBlocks\Traits\IsRepeaterBlockResource;
 use Epartment\NovaDependencyContainer\NovaDependencyContainer;
@@ -43,7 +42,7 @@ class ImageBlock extends Resource
     public function fields(Request $request)
     {
         return [
-            Image::make('Image')->disk('public'),
+            config('repeater-blocks.images.field')::make('Image')->disk(config('repeater-blocks.images.disk')),
             Text::make('Alt Content')->rules('required', 'max:254'),
         ];
     }

--- a/src-php/Support/RenderEngine.php
+++ b/src-php/Support/RenderEngine.php
@@ -12,7 +12,7 @@ class RenderEngine
      */
     public static function renderRepeaters($model)
     {
-        if(!array_get($model, 'repeaters')) {
+        if (!array_get($model, 'repeaters')) {
             return null;
         }
 


### PR DESCRIPTION
To make image handling more flexible without having to extend resources the nova image field and disk can be defined in the config. E.g. we typically just use Cloudinary but don't want to make this the default. This makes it super easy to exchange the image field with another compatible one.

There are a couple of other minor tweaks / fixes here too.