### PR TITLE
Select a custom block from list

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ public function fields(Request $request)
 }
 ```
 
+## Custom View Block
+
+The custom view block allows you to use an HTML view template as a repeater block.  To use this block, the custom templates you create must be stored in the path definited in the `repeater-blocks` configuration file.  By default, the path for your custom templates is `resources/views/repeaters/custom`.
+
+Once your custom views have been created, they will be available in the 'Template Name' dropdown list when you select the 'Custom View' repeater type.
+
 ## Advanced Nested Repeater Blocks
 
 Any repeater block can have more nested repeater blocks if desired. In order to achieve this, the repeater block model must have a `types` method indicating what types can be added to the block. Each of these types must include a `sourceTypes` method, you should be able to simply reference the parent block `types`.

--- a/src-php/Config/repeater-blocks.php
+++ b/src-php/Config/repeater-blocks.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'path' => 'repeaters.',
+    'path' => 'repeaters.custom.',
     'images' => [
         'field' => 'Laravel\Nova\Fields\Image',
         'disk' => 'public',

--- a/src-php/Models/Repeater.php
+++ b/src-php/Models/Repeater.php
@@ -2,6 +2,7 @@
 
 namespace Dewsign\NovaRepeaterBlocks\Models;
 
+use Illuminate\Support\Facades\File;
 use Spatie\EloquentSortable\Sortable;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\EloquentSortable\SortableTrait;
@@ -57,5 +58,33 @@ class Repeater extends Model implements Sortable
         static::deleted(function ($model) {
             optional($model->repeatable)->save();
         });
+    }
+
+    public static function customTemplates()
+    {
+        $templatePath = static::getTemplatePath();
+        $templates = File::exists($templatePath) ? File::files($templatePath) : null;
+
+        return collect($templates)->mapWithKeys(function ($file) {
+            $filename = $file->getFilename();
+
+            return [
+                str_replace('.blade.php', '', $filename) => static::getPrettyFilename($filename),
+            ];
+        })->all();
+    }
+
+    private static function getTemplatePath()
+    {
+        $path = str_replace('.', '/', config('repeater-blocks.path'));
+
+        return resource_path('views/' . $path);
+    }
+
+    private static function getPrettyFilename($filename)
+    {
+        $basename = str_replace('.blade.php', '', $filename);
+
+        return title_case(str_replace('-', ' ', $basename));
     }
 }

--- a/src-php/Repeaters/Common/Blocks/CustomViewBlock.php
+++ b/src-php/Repeaters/Common/Blocks/CustomViewBlock.php
@@ -4,7 +4,8 @@ namespace Dewsign\NovaRepeaterBlocks\Repeaters\Common\Blocks;
 
 use Laravel\Nova\Resource;
 use Illuminate\Http\Request;
-use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\Select;
+use Dewsign\NovaRepeaterBlocks\Models\Repeater;
 use Epartment\NovaDependencyContainer\HasDependencies;
 use Dewsign\NovaRepeaterBlocks\Traits\IsRepeaterBlockResource;
 use Epartment\NovaDependencyContainer\NovaDependencyContainer;
@@ -40,8 +41,13 @@ class CustomViewBlock extends Resource
 
     public function fields(Request $request)
     {
+        $options = Repeater::customTemplates();
+
         return [
-            Text::make('Template Name')->rules('required', 'max:254'),
+            Select::make('Template Name')
+                ->options($options)
+                ->displayUsingLabels()
+                ->hideFromIndex(),
         ];
     }
 }


### PR DESCRIPTION
Similar to the page templates on nova-pages, this allows the user to select from the available custom blocks in the directory set in the configuration file.

Something to note; the 'custom block' templates in the application should be stored in a different directory to the templates which are created when new repeater blocks are built out in the application.