### PR TITLE
Containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ The custom view block allows you to use an HTML view template as a repeater bloc
 
 Once your custom views have been created, they will be available in the 'Template Name' dropdown list when you select the 'Custom View' repeater type.
 
+## Containers
+
+All the default blocks included can be Containerised. Essentially a way of grouping multiple repeaters in a container. You can create new container types by creating new templates inside the `resources/views/vendor/nova-repeater-blocks/container` directory. These will automatically appear in the Select options.
+
+You can allow custom repeater blocks to be containerised by adding the `CanBeContainerised` trait to the model and `ResourceCanBeContainerised` to the Block resource.
+
 ## Advanced Nested Repeater Blocks
 
 Any repeater block can have more nested repeater blocks if desired. In order to achieve this, the repeater block model must have a `types` method indicating what types can be added to the block. Each of these types must include a `sourceTypes` method, you should be able to simply reference the parent block `types`.

--- a/src-php/Config/repeater-blocks.php
+++ b/src-php/Config/repeater-blocks.php
@@ -6,4 +6,12 @@ return [
         'field' => 'Laravel\Nova\Fields\Image',
         'disk' => 'public',
     ],
+    'repeaters' => [
+        Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models\TextBlock::class,
+        Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models\ImageBlock::class,
+        Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models\MarkdownBlock::class,
+        Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models\TextareaBlock::class,
+        Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models\ContainerBlock::class,
+        Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models\CustomViewBlock::class,
+    ],
 ];

--- a/src-php/Database/migrations/2019_01_09_000001_create_container_blocks_table.php
+++ b/src-php/Database/migrations/2019_01_09_000001_create_container_blocks_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateContainerBlocksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('container_blocks', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('template')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('container_blocks');
+    }
+}

--- a/src-php/Models/Repeater.php
+++ b/src-php/Models/Repeater.php
@@ -60,9 +60,9 @@ class Repeater extends Model implements Sortable
         });
     }
 
-    public static function customTemplates()
+    public static function customTemplates($path = null)
     {
-        $templatePath = static::getTemplatePath();
+        $templatePath = $path ?? static::getTemplatePath();
         $templates = File::exists($templatePath) ? File::files($templatePath) : null;
 
         return collect($templates)->mapWithKeys(function ($file) {

--- a/src-php/Repeaters/Common/AvailableBlocks.php
+++ b/src-php/Repeaters/Common/AvailableBlocks.php
@@ -2,23 +2,31 @@
 
 namespace Dewsign\NovaRepeaterBlocks\Repeaters\Common;
 
-use Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models\TextBlock;
-use Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models\ImageBlock;
-use Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models\TextareaBlock;
-use Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models\MarkdownBlock;
-use Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models\CustomViewBlock;
+use Dewsign\NovaRepeaterBlocks\Traits\ResourceCanBeContainerised;
 
 class AvailableBlocks
 {
+    /**
+     * Return all available blocks
+     *
+     * @return array
+     */
     public static function all()
     {
-        return [
-            TextBlock::class,
-            TextareaBlock::class,
-            ImageBlock::class,
-            CustomViewBlock::class,
-            MarkdownBlock::class,
-        ];
+        return config('nova-repeater-blocks.repeaters');
+    }
+
+    /**
+     * Return the blocks which can be included in containers
+     *
+     * @return array
+     */
+    public static function containable()
+    {
+        return collect(config('nova-repeater-blocks.repeaters'))
+            ->filter(function ($block) {
+                return in_array(ResourceCanBeContainerised::class, class_uses($block));
+            })->toArray();
     }
 
     public static function random()

--- a/src-php/Repeaters/Common/Blocks/ContainerBlock.php
+++ b/src-php/Repeaters/Common/Blocks/ContainerBlock.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Dewsign\NovaRepeaterBlocks\Repeaters\Common\Blocks;
+
+use Laravel\Nova\Resource;
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Select;
+use Dewsign\NovaRepeaterBlocks\Models\Repeater;
+use Epartment\NovaDependencyContainer\HasDependencies;
+use Dewsign\NovaRepeaterBlocks\Traits\IsRepeaterBlockResource;
+use Epartment\NovaDependencyContainer\NovaDependencyContainer;
+use Dewsign\NovaRepeaterBlocks\Traits\ResourceCanBeContainerised;
+
+class ContainerBlock extends Resource
+{
+    use HasDependencies;
+    use IsRepeaterBlockResource;
+    use ResourceCanBeContainerised;
+
+    public static $model = 'Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models\ContainerBlock';
+
+    /**
+     * The single value that should be used to represent the resource when being displayed.
+     *
+     * @var string
+     */
+    public static $title = 'name';
+
+    /**
+     * The columns that should be searched.
+     *
+     * @var array
+     */
+    public static $search = [
+        'id',
+        'template',
+    ];
+
+    public static function label()
+    {
+        return __('Containers');
+    }
+
+    public function fields(Request $request)
+    {
+        $packageTemplates = Repeater::customTemplates(__DIR__ . '/../../../Resources/views/container');
+        $appTemplates = Repeater::customTemplates(resource_path('views/vendor/nova-repeater-blocks/container'));
+
+        return [
+            Select::make('Template')
+                ->options(array_merge($packageTemplates, $appTemplates))
+                ->displayUsingLabels()
+                ->hideFromIndex(),
+        ];
+    }
+}

--- a/src-php/Repeaters/Common/Blocks/CustomViewBlock.php
+++ b/src-php/Repeaters/Common/Blocks/CustomViewBlock.php
@@ -9,11 +9,13 @@ use Dewsign\NovaRepeaterBlocks\Models\Repeater;
 use Epartment\NovaDependencyContainer\HasDependencies;
 use Dewsign\NovaRepeaterBlocks\Traits\IsRepeaterBlockResource;
 use Epartment\NovaDependencyContainer\NovaDependencyContainer;
+use Dewsign\NovaRepeaterBlocks\Traits\ResourceCanBeContainerised;
 
 class CustomViewBlock extends Resource
 {
     use HasDependencies;
     use IsRepeaterBlockResource;
+    use ResourceCanBeContainerised;
 
     public static $model = 'Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models\CustomViewBlock';
 

--- a/src-php/Repeaters/Common/Blocks/ImageBlock.php
+++ b/src-php/Repeaters/Common/Blocks/ImageBlock.php
@@ -8,11 +8,13 @@ use Laravel\Nova\Fields\Text;
 use Epartment\NovaDependencyContainer\HasDependencies;
 use Dewsign\NovaRepeaterBlocks\Traits\IsRepeaterBlockResource;
 use Epartment\NovaDependencyContainer\NovaDependencyContainer;
+use Dewsign\NovaRepeaterBlocks\Traits\ResourceCanBeContainerised;
 
 class ImageBlock extends Resource
 {
     use HasDependencies;
     use IsRepeaterBlockResource;
+    use ResourceCanBeContainerised;
 
     public static $model = 'Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models\ImageBlock';
 

--- a/src-php/Repeaters/Common/Blocks/MarkdownBlock.php
+++ b/src-php/Repeaters/Common/Blocks/MarkdownBlock.php
@@ -9,11 +9,13 @@ use Laravel\Nova\Fields\Textarea;
 use Epartment\NovaDependencyContainer\HasDependencies;
 use Dewsign\NovaRepeaterBlocks\Traits\IsRepeaterBlockResource;
 use Epartment\NovaDependencyContainer\NovaDependencyContainer;
+use Dewsign\NovaRepeaterBlocks\Traits\ResourceCanBeContainerised;
 
 class MarkdownBlock extends Resource
 {
     use HasDependencies;
     use IsRepeaterBlockResource;
+    use ResourceCanBeContainerised;
 
     public static $model = 'Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models\MarkdownBlock';
 

--- a/src-php/Repeaters/Common/Blocks/TextBlock.php
+++ b/src-php/Repeaters/Common/Blocks/TextBlock.php
@@ -9,11 +9,13 @@ use Laravel\Nova\Fields\Select;
 use Epartment\NovaDependencyContainer\HasDependencies;
 use Dewsign\NovaRepeaterBlocks\Traits\IsRepeaterBlockResource;
 use Epartment\NovaDependencyContainer\NovaDependencyContainer;
+use Dewsign\NovaRepeaterBlocks\Traits\ResourceCanBeContainerised;
 
 class TextBlock extends Resource
 {
     use HasDependencies;
     use IsRepeaterBlockResource;
+    use ResourceCanBeContainerised;
 
     public static $model = 'Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models\TextBlock';
 

--- a/src-php/Repeaters/Common/Blocks/TextareaBlock.php
+++ b/src-php/Repeaters/Common/Blocks/TextareaBlock.php
@@ -6,10 +6,12 @@ use Laravel\Nova\Resource;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Textarea;
 use Dewsign\NovaRepeaterBlocks\Traits\IsRepeaterBlockResource;
+use Dewsign\NovaRepeaterBlocks\Traits\ResourceCanBeContainerised;
 
 class TextareaBlock extends Resource
 {
     use IsRepeaterBlockResource;
+    use ResourceCanBeContainerised;
 
     public static $model = 'Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models\TextareaBlock';
 

--- a/src-php/Repeaters/Common/Models/ContainerBlock.php
+++ b/src-php/Repeaters/Common/Models/ContainerBlock.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Dewsign\NovaRepeaterBlocks\Traits\IsRepeaterBlock;
+use Dewsign\NovaRepeaterBlocks\Traits\HasRepeaterBlocks;
+use Dewsign\NovaRepeaterBlocks\Traits\CanBeContainerised;
+use Dewsign\NovaRepeaterBlocks\Repeaters\Common\AvailableBlocks;
+use Dewsign\NovaRepeaterBlocks\Repeaters\Common\Blocks\MarkdownBlock;
+
+class ContainerBlock extends Model
+{
+    use IsRepeaterBlock;
+    use HasRepeaterBlocks;
+    use CanBeContainerised;
+
+    public static $repeaterBlockViewTemplate = 'nova-repeater-blocks::container.default';
+
+    public static function types()
+    {
+        return AvailableBlocks::containable();
+    }
+}

--- a/src-php/Repeaters/Common/Models/CustomViewBlock.php
+++ b/src-php/Repeaters/Common/Models/CustomViewBlock.php
@@ -4,10 +4,12 @@ namespace Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Dewsign\NovaRepeaterBlocks\Traits\IsRepeaterBlock;
+use Dewsign\NovaRepeaterBlocks\Traits\CanBeContainerised;
 
 class CustomViewBlock extends Model
 {
     use IsRepeaterBlock;
+    use CanBeContainerised;
 
     public static $repeaterBlockViewTemplate = 'nova-repeater-blocks::common.customview';
 }

--- a/src-php/Repeaters/Common/Models/ImageBlock.php
+++ b/src-php/Repeaters/Common/Models/ImageBlock.php
@@ -4,10 +4,12 @@ namespace Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Dewsign\NovaRepeaterBlocks\Traits\IsRepeaterBlock;
+use Dewsign\NovaRepeaterBlocks\Traits\CanBeContainerised;
 
 class ImageBlock extends Model
 {
     use IsRepeaterBlock;
+    use CanBeContainerised;
 
     public static $repeaterBlockViewTemplate = 'nova-repeater-blocks::common.image';
 }

--- a/src-php/Repeaters/Common/Models/MarkdownBlock.php
+++ b/src-php/Repeaters/Common/Models/MarkdownBlock.php
@@ -4,10 +4,12 @@ namespace Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Dewsign\NovaRepeaterBlocks\Traits\IsRepeaterBlock;
+use Dewsign\NovaRepeaterBlocks\Traits\CanBeContainerised;
 
 class MarkdownBlock extends Model
 {
     use IsRepeaterBlock;
+    use CanBeContainerised;
 
     public static $repeaterBlockViewTemplate = 'nova-repeater-blocks::common.markdown';
 }

--- a/src-php/Repeaters/Common/Models/TextBlock.php
+++ b/src-php/Repeaters/Common/Models/TextBlock.php
@@ -4,10 +4,12 @@ namespace Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Dewsign\NovaRepeaterBlocks\Traits\IsRepeaterBlock;
+use Dewsign\NovaRepeaterBlocks\Traits\CanBeContainerised;
 
 class TextBlock extends Model
 {
     use IsRepeaterBlock;
+    use CanBeContainerised;
 
     public static $repeaterBlockViewTemplate = 'nova-repeater-blocks::common.text';
 }

--- a/src-php/Repeaters/Common/Models/TextareaBlock.php
+++ b/src-php/Repeaters/Common/Models/TextareaBlock.php
@@ -4,10 +4,12 @@ namespace Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Dewsign\NovaRepeaterBlocks\Traits\IsRepeaterBlock;
+use Dewsign\NovaRepeaterBlocks\Traits\CanBeContainerised;
 
 class TextareaBlock extends Model
 {
     use IsRepeaterBlock;
+    use CanBeContainerised;
 
     public static $repeaterBlockViewTemplate = 'nova-repeater-blocks::common.textarea';
 }

--- a/src-php/Resources/views/container/default.blade.php
+++ b/src-php/Resources/views/container/default.blade.php
@@ -1,0 +1,3 @@
+<div>
+    @repeaterblocks($repeaters)
+</div>

--- a/src-php/Resources/views/container/default.blade.php
+++ b/src-php/Resources/views/container/default.blade.php
@@ -1,3 +1,3 @@
 <div>
-    @repeaterblocks($repeaters)
+    @repeaterblocks($repeater)
 </div>

--- a/src-php/Traits/CanBeContainerised.php
+++ b/src-php/Traits/CanBeContainerised.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Dewsign\NovaRepeaterBlocks\Traits;
+
+use Dewsign\NovaRepeaterBlocks\Repeaters\Common\Models\ContainerBlock;
+
+trait CanBeContainerised
+{
+    public static function sourceTypes()
+    {
+        return ContainerBlock::types();
+    }
+}

--- a/src-php/Traits/ResourceCanBeContainerised.php
+++ b/src-php/Traits/ResourceCanBeContainerised.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Dewsign\NovaRepeaterBlocks\Traits;
+
+trait ResourceCanBeContainerised
+{
+    //
+}


### PR DESCRIPTION
Allow any repeater block to potentially be grouped inside a container. Ideal for wrapping any blocks inside a group element. The container types can be customised through the views/vendor folder, see readme.