### PR TITLE
Random available blocks now returns only seedable blocks.

### DIFF
--- a/src-php/Repeaters/Common/AvailableBlocks.php
+++ b/src-php/Repeaters/Common/AvailableBlocks.php
@@ -29,9 +29,24 @@ class AvailableBlocks
             })->toArray();
     }
 
+    public static function seedable()
+    {
+        $collected = collect(config('repeater-blocks.repeaters'))
+            ->filter(function ($block) {
+                try {
+                    return factory($block::$model)->make();
+                }
+                catch(\Exception $e) {
+                    return false;
+                }
+            })->toArray();
+
+        return $collected;
+    }
+
     public static function random()
     {
-        $all = static::all();
+        $all = static::seedable();
         return $all[array_rand($all)];
     }
 }


### PR DESCRIPTION
Change the random function on `AvailableBlocks` to only return repeater blocks that are actually seedable.