### PR TITLE
Model helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The following naming sequence will be used to find the correct template to rende
 
 The repeater block view will receive the following parameters:
 
-|Key|Content Type|Pupose|
+|Key|Content Type|Purpose|
 |---|----|---|
 |repeater|Object|The complete repeater base model|
 |repeaterKey|String|The key used to find the template|
@@ -190,7 +190,7 @@ To pass data into this, call `getExtraInfo()` on your repeater resource.
 
 ## Custom View Block
 
-The custom view block allows you to use an HTML view template as a repeater block.  To use this block, the custom templates you create must be stored in the path definited in the `repeater-blocks` configuration file.  By default, the path for your custom templates is `resources/views/repeaters/custom`.
+The custom view block allows you to use an HTML view template as a repeater block.  To use this block, the custom templates you create must be stored in the path defined in the `repeater-blocks` configuration file.  By default, the path for your custom templates is `resources/views/repeaters/custom`.
 
 Once your custom views have been created, they will be available in the 'Template Name' dropdown list when you select the 'Custom View' repeater type.
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ public function fields(Request $request)
 }
 ```
 
-There is an included `getExtraInfo()` function that allows you to pass in any information you would like displayed on the Repeaters index view.
+There is an included `getExtraInfo()` function that allows you to pass in any information you would like displayed on the Repeaters index view inside the Laravel Nova Admin UI.
 
 To pass data into this, call `getExtraInfo()` on your repeater resource.
 
@@ -206,7 +206,7 @@ You can allow custom repeater blocks to be containerised by adding the `CanBeCon
 
 You can create multiple image styles by adding new templates to the `/views/vendor/nova-repeater-blocks/common/image` resource folder. The system will fallback to the default style if a view is not found.
 
-### Image Procesing
+### Image Processing
 
 The config provides an easy way to customise the Image Processor. Create a new class with a compatible get method which can return the processed image url. Each Item template can have a unique image processor. Some common template names are included but they all render the default template (typically sufficient when combined with the Image Processor).
 

--- a/src-php/Traits/ResolvesRepeaterTypes.php
+++ b/src-php/Traits/ResolvesRepeaterTypes.php
@@ -2,8 +2,19 @@
 
 namespace Dewsign\NovaRepeaterBlocks\Traits;
 
+/**
+ * This trait enabled repeaters to share commonly used attributes
+ * across any polymorphic relation without knowing it's type.
+ *
+ * The associated target methods need to be implemented on the related model.
+ */
 trait ResolvesRepeaterTypes
 {
+    /**
+     * Return the target URL from the relation to link to.
+     *
+     * @return String
+     */
     public function getActionAttribute()
     {
         if (!method_exists($this->type, 'resolveAction')) {
@@ -13,6 +24,11 @@ trait ResolvesRepeaterTypes
         return $this->type->resolveAction();
     }
 
+    /**
+     * Return the label to use when displaying this resource
+     *
+     * @return String
+     */
     public function getLabelAttribute()
     {
         if (!method_exists($this->type, 'resolveLabel')) {
@@ -22,6 +38,12 @@ trait ResolvesRepeaterTypes
         return $this->type->resolveLabel($this);
     }
 
+    /**
+     * This view will be rendered when using the @repeaterblocks helper in your views.
+     * NOTE: Use {!! $item->view !!} when accessing this manually
+     *
+     * @return String
+     */
     public function getViewAttribute()
     {
         if (!method_exists($this->type, 'resolveView')) {

--- a/src-php/Traits/ResolvesRepeaterTypes.php
+++ b/src-php/Traits/ResolvesRepeaterTypes.php
@@ -30,4 +30,18 @@ trait ResolvesRepeaterTypes
 
         return $this->type->resolveView($this);
     }
+
+    /**
+     * Make a desired model accessible from a repeater without knowing its name or type.
+     *
+     * @return mixed
+     */
+    public function getModelAttribute()
+    {
+        if (!method_exists($this->type, 'resolveModel')) {
+            return null;
+        }
+
+        return $this->type->resolveModel($this);
+    }
 }


### PR DESCRIPTION
Ran into a situation where I needed to access an attribute from a Repeater -> Type -> Some Related Model from the repeater itself, without the repeater knowing what the final target relation is. This allows you to define a `resolveModel` method on the `Type` which can return the required relation, making it accessible as a `model` attribute.

The current use case is the Navigation module which uses repeaters and each one is a lookup of a related model. E.g. a page, or a blog article, or an author profile.

While in there I also added some doc blocks to try and make things easier to understand.