### PR TITLE
Delete images when a repeater is deleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,14 +218,20 @@ Here is an example of a custom Image Processor to replace the defaults
 namespace App\Processors;
 
 use Illuminate\Support\Facades\Storage;
+use Dewsign\NovaRepeaterBlocks\Processors\ImageProcessor;
 
-class DefaultImageProcessor
+class DefaultImageProcessor extends ImageProcessor
 {
     public static function get(string $image, array $params = [])
     {
         // Process the image and perform any special tasks before returning the final Image URL.
 
         return $myImageURL;
+    }
+
+    public static function delete(string $image)
+    {
+        // Handle the deletion of the image (e.g. from a remote filesystem)
     }
 }
 ```

--- a/src-php/Processors/ImageProcessor.php
+++ b/src-php/Processors/ImageProcessor.php
@@ -10,4 +10,9 @@ class ImageProcessor
     {
         return Storage::disk(config('repeater-blocks.images.disk'))->url($image);
     }
+
+    public static function delete(string $image)
+    {
+        return Storage::disk(config('repeater-blocks.images.disk'))->delete($image);
+    }
 }

--- a/src-php/Repeaters/Common/Models/ImageBlock.php
+++ b/src-php/Repeaters/Common/Models/ImageBlock.php
@@ -17,6 +17,18 @@ class ImageBlock extends Model
         'default_image',
     ];
 
+    public static function boot()
+    {
+        parent::boot();
+
+        static::deleting(function ($model) {
+            return config(
+                "repeater-blocks.images.processors.{$model->style}",
+                config("repeater-blocks.images.processors.default")
+            )::delete($model->image);
+        });
+    }
+
     public function getDefaultImageAttribute()
     {
         return $this->getImage();


### PR DESCRIPTION
What it says on the tin. 

Previously, when deleting a repeater image block, the source file was not deleted. This PR addresses this and deletes the source file through the ImageProcessor. This makes is super easy to customise the delete functionality for remote drivers such as Cloudinary.

Have included an update to the Readme to ensure this functionality is visible.