### PR TITLE
Fallback for $this->viewable on RepeatableBelongsTo

### DIFF
--- a/src-php/Fields/RepeatableBelongsTo.php
+++ b/src-php/Fields/RepeatableBelongsTo.php
@@ -23,7 +23,7 @@ class RepeatableBelongsTo extends BelongsTo
             'belongsToRelationship' => $this->belongsToRelationship,
             'belongsToId' => $this->belongsToId,
             'searchable' => $this->searchable,
-            'viewable' => $this->viewable,
+            'viewable' => $this->viewable ?? true,
             'reverse' => false,
         ], $this->meta);
     }


### PR DESCRIPTION
Added a fallback for `$this->viewable` on the `RepeatableBelongsTo` field. Missed this during the upgrade to nova 2.0.