### PR TITLE
Avoid errors on repeaters with belongs to.

### DIFF
--- a/src-php/Fields/RepeatableBelongsTo.php
+++ b/src-php/Fields/RepeatableBelongsTo.php
@@ -27,4 +27,27 @@ class RepeatableBelongsTo extends BelongsTo
             'reverse' => false,
         ], $this->meta);
     }
+
+    /**
+     * This method has been overloaded to remove the 'reverse' lookup because
+     * it causes some strange errors. No time to properly resovle the cause so
+     * we are hacking it like this for the moment. Doesn't appear to have caused
+     * any side-effects so far. Also removed the parent::jsonSerialize here.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'belongsToId' => $this->belongsToId,
+            'belongsToRelationship' => $this->belongsToRelationship,
+            'label' => forward_static_call([$this->resourceClass, 'label']),
+            'resourceName' => $this->resourceName,
+            // 'reverse' => $this->isReverseRelation(app(NovaRequest::class)),
+            'searchable' => $this->searchable,
+            'singularLabel' => $this->singularLabel,
+            'viewable' => $this->viewable,
+            'displaysWithTrashed' => $this->displaysWithTrashed,
+        ];
+    }
 }


### PR DESCRIPTION
Some of my finest work here!

This issue only happened when creating a repeater with a belongsto which references the same model (E.g. Page) as the parent of the repeater.

So adding a direct repeater to a `Page` with a BelongsTo which references a `Page`.

No time to work out a proper fix, so here's some hacky fix! What fun 🎉 